### PR TITLE
Worker log to database

### DIFF
--- a/mtq/defaults.py
+++ b/mtq/defaults.py
@@ -3,6 +3,6 @@ Default values for the queue
 '''
 _collection_base = 'mq'
 _qsize = 50
-_logsize = 100
+_logsize = 1000
 _workersize = 5
 _task_map = {}

--- a/mtq/log.py
+++ b/mtq/log.py
@@ -11,7 +11,7 @@ import time
 
 class ColorStreamHandler(logging.Handler):
     '''
-    Handler to write to stdout with colored output 
+    Handler to write to stdout with colored output
     '''
     WARNING = '\033[93m'
     OKBLUE = '\033[94m'
@@ -24,10 +24,10 @@ class ColorStreamHandler(logging.Handler):
                  'DEBUG': '%s%s[%%s]%s' % (BOLD, OKBLUE, ENDC),
                  'INFO': '%s%s[%%s]%s' % (BOLD, OKBLUE, ENDC),
                  }
-    
+
     def color_map(self, header, level):
-        return self.COLOR_MAP.get(level, '[%s]') % header  
-    
+        return self.COLOR_MAP.get(level, '[%s]') % header
+
     def __init__(self, level=logging.INFO):
         logging.Handler.__init__(self, level=level)
     def emit(self, record):
@@ -48,7 +48,7 @@ class ColorStreamHandler(logging.Handler):
             else:
                 header = record.name
                 message = record.getMessage()
-                
+
         if stream.isatty() and not sys.platform.startswith('win'):
             header = self.color_map(header, record.levelname)
         stream.write('%s %s\n' % (header, message))
@@ -61,7 +61,7 @@ class BSONFormatter(object):
     def __init__(self, *args, **extra_tags):
         object.__init__(self, *args)
         self.extra_tags = extra_tags
-        
+
     def format(self, record):
         if isinstance(record.msg, dict):
             data = record.msg
@@ -69,23 +69,23 @@ class BSONFormatter(object):
             data = {'items': record.msg}
         else:
             data = {'message':'%s\n' % (record.msg,)}
-            
+
         data.update(logLevel=record.levelname, logModule=record.module, logName=record.name, **self.extra_tags)
-        return data 
+        return data
 
 class MongoHandler(logging.Handler):
     '''
     Log to monog db
     '''
     def __init__(self, collection, doc):
-        
+
         logging.Handler.__init__(self, logging.INFO)
-        
+
         self.collection = collection
         self.doc = doc
         self.setFormatter(BSONFormatter())
-        
-        
+
+
     def emit(self, record):
         doc = self.doc.copy()
         data = self.format(record)
@@ -103,36 +103,36 @@ class TextIOWrapperSmart(io.TextIOWrapper):
 
 class IOStreamLogger(logging.Logger):
     def __init__(self, stream, silence=False):
-        
+
         self.stream_name = name = getattr(stream, 'name', None)
         logging.Logger.__init__(self, name, level=logging.INFO)
         self.stream = stream
         self.silence = silence
-        
+
         hdlr = logging.StreamHandler(stream)
         hdlr.setLevel(logging.INFO)
         self.addHandler(hdlr)
-        
+
     def readable(self):
         return 'r' in self.stream.mode
-    
+
     @property
     def closed(self):
         return self.stream.closed
-    
+
     def writable(self):
-        return 'w' in self.stream.mode or 'a' in self.stream.mode  
+        return 'w' in self.stream.mode or 'a' in self.stream.mode
 
     def seekable(self):
         return False
-    
+
     def write(self, message):
         self.info(message)
         return len(message)
-    
+
     def flush(self):
         self.stream.flush()
-    
+
 
 class MongoStream(object):
     '''
@@ -145,36 +145,36 @@ class MongoStream(object):
         self._finished = finished
         self.silence = silence
         self.stream_name = getattr(stream, 'name', None)
-        
+
     def readable(self):
         return False
-    
+
     @property
     def closed(self):
         return False
-    
+
     def writable(self):
         return True
 
     def seekable(self):
         return False
-    
+
     def write(self, message):
         doc = self.doc.copy()
         doc.update(message=message, time=now())
-        
+
         self.collection.insert(doc)
-        
+
         if self.stream and not self.silence:
             self.stream.write(message)
         return len(message)
-    
+
     def flush(self):
         pass
-    
+
     def loglines(self, follow=False):
         starting_finished = not follow or self._finished()
-        
+
         cursor = self.collection.find(self.doc,
                                       await_data=not starting_finished,
                                       tailable=not starting_finished)
@@ -182,21 +182,21 @@ class MongoStream(object):
             for item in cursor:
                 text = item.get('message', '')
                 yield text
-            
+
             if starting_finished or self._finished():
                 return
-            
+
             time.sleep(1)
-            
+
         return
-    
+
 def mstream(collection, doc, stream=None, silence=False):
     '''
-    Create a buffered mongo stream (good for print statements) 
+    Create a buffered mongo stream (good for print statements)
     '''
     return TextIOWrapperSmart(MongoStream(collection, doc, sys.stdout, silence), line_buffering=True)
-    
-    
+
+
 
 def add_all(loggers, handlers):
     for l in loggers:

--- a/mtq/tests/fixture.py
+++ b/mtq/tests/fixture.py
@@ -1,17 +1,25 @@
 import unittest
 import pymongo
 import mtq
+import logging
+
+log = logging.getLogger('mtq.test')
+log.setLevel(logging.INFO)
 
 
 def test_func(*args, **kwargs):
+    log.info('Running test_func')
     return args, kwargs
 
+
 def test_func_fail(*args, **kwargs):
+    log.warning('Raising a test exception in test_func_fail')
     raise Exception()
 
 
 class MTQTestCase(unittest.TestCase):
     connection = None
+
     def setUp(self):
         if type(self).connection is None:
             type(self).connection = pymongo.MongoClient()
@@ -20,6 +28,9 @@ class MTQTestCase(unittest.TestCase):
         self.factory = mtq.create_connection(db=self.db)
 
     def tearDown(self):
+        # uncomment to dump database state after each test
+        # from pprint import pprint
+        # for coll in self.db.collection_names():
+        #     print('\n%s:' % coll)
+        #     pprint(list(self.db[coll].find()))
         self.connection.drop_database('mtq_testing')
-
-

--- a/mtq/tests/runtests.py
+++ b/mtq/tests/runtests.py
@@ -16,7 +16,7 @@ def main():
     loader = unittest.loader.TestLoader()
     tests = loader.discover(dirname(__file__))
     runner = unittest.TextTestRunner()
-    runner.run(tests) 
+    runner.run(tests)
     cov.stop()
     cov.save()
     cov.report()

--- a/mtq/utils.py
+++ b/mtq/utils.py
@@ -143,7 +143,7 @@ Job Log:
 
 
 @contextmanager
-def setup_logging(collection, worker_id, job_id, lognames=()):
+def setup_logging(collection, job_id, lognames=()):
     """
     set up logging for worker
     """

--- a/mtq/worker.py
+++ b/mtq/worker.py
@@ -206,7 +206,7 @@ class Worker(object):
         '''
         handle_signals()
 
-        with setup_logging(self.factory.logging_collection, self.worker_id, job.id, lognames=self.extra_lognames):
+        with setup_logging(self.factory.logging_collection, job.id, lognames=self.extra_lognames):
             try:
                 self._pre(job)
                 job.apply()

--- a/mtq/worker.py
+++ b/mtq/worker.py
@@ -14,6 +14,8 @@ from mtq.utils import handle_signals, now, setup_logging, nulltime
 
 
 class Worker(object):
+    worker_id = '-'
+
     '''
     Should create a worker from MTQConnection.new_worker
     '''
@@ -41,9 +43,6 @@ class Worker(object):
 
         self.collection = self.factory.worker_collection
 
-
-    worker_id = '-'
-
     @contextmanager
     def register(self):
         '''
@@ -61,10 +60,10 @@ class Worker(object):
                                                  'system': platform.system(),
                                                  'pid': os.getgid(),
                                                  'user': getpass.getuser(),
-                                                 'started':now(),
-                                                 'finished':datetime.fromtimestamp(0),
-                                                 'check-in':datetime.fromtimestamp(0),
-                                                 'working':True,
+                                                 'started': now(),
+                                                 'finished': datetime.fromtimestamp(0),
+                                                 'check-in': datetime.fromtimestamp(0),
+                                                 'working': True,
                                                  'queues': self.queues,
                                                  'tags': self.tags,
                                                  'log_output': bool(self._log_worker_output),
@@ -72,7 +71,7 @@ class Worker(object):
                                                  'terminate_status': 0,
                                                  })
         if self._log_worker_output:
-            hdlr = MongoHandler(self.factory.logging_collection, {'worker_id':self.worker_id})
+            hdlr = MongoHandler(self.factory.logging_collection, {'worker_id': self.worker_id})
             self.logger.addHandler(hdlr)
         try:
             yield self.worker_id
@@ -81,13 +80,13 @@ class Worker(object):
                 self.logger.removeHandler(hdlr)
 
             query = {'_id': self.worker_id}
-            update = {'$set':{'finished':now(), 'working':False}}
+            update = {'$set': {'finished': now(), 'working': False}}
             self.collection.update(query, update)
 
     def check_in(self):
 
         query = {'_id': self.worker_id}
-        update = {'$set':{'check-in':now(), 'working':True}}
+        update = {'$set': {'check-in': now(), 'working': True}}
         worker_info = self.collection.find_and_modify(query, update)
         if worker_info:
             should_exit = worker_info.get('terminate', False)
@@ -127,10 +126,13 @@ class Worker(object):
         '''
         Start the main loop and process jobs
         '''
-        self.logger.info('Starting Main Loop mogno-host=%s mongo-db=%s' % (self.factory.db.connection.host,
-                                                                           self.factory.db.name))
+        self.logger.info('Starting Main Loop mogno-host=%s mongo-db=%s' % (
+            self.factory.db.connection.host,
+            self.factory.db.name))
         self.logger.info('Starting Main Loop worker=%s _id=%s' % (self.name, self.worker_id))
-        self.logger.info('Listening for jobs queues=[%s] tags=[%s]' % (', '.join(self.queues), ', '.join(self.tags)))
+        self.logger.info('Listening for jobs queues=[%s] tags=[%s]' % (
+            ', '.join(self.queues),
+            ', '.join(self.tags)))
 
         while 1:
             try:
@@ -142,22 +144,29 @@ class Worker(object):
                 job = self.pop_item(pop_failed=pop_failed)
 
                 if job is None:
-                    if batch: break
+                    if batch:
+                        break
                     time.sleep(self.poll_interval)
                     continue
 
                 self.process_job(job)
 
-                if one: break
+                if one:
+                    break
 
-                self.logger.info('Listening for jobs queues=[%s] tags=[%s]' % (', '.join(self.queues), ', '.join(self.tags)))
+                self.logger.info('Listening for jobs queues=[%s] tags=[%s]' % (
+                    ', '.join(self.queues), ', '.join(self.tags)))
 
             except Exception as err:
-                if fail_fast: raise
-                else: self.logger.exception(err)
+                if fail_fast:
+                    raise
+                else:
+                    self.logger.exception(err)
 
-                if one: break
-                else: continue
+                if one:
+                    break
+                else:
+                    continue
 
         self.logger.info('Exiting Main Loop')
 
@@ -165,7 +174,8 @@ class Worker(object):
         '''
         Process a single job in a multiprocessing.Process
         '''
-        self.logger.info('Popped Job _id=%s queue=%s tags=%s' % (job.id, job.qname, ', '.join(job.tags)))
+        self.logger.info('Popped Job _id=%s queue=%s tags=%s' % (
+            job.id, job.qname, ', '.join(job.tags)))
         self.logger.info(job.call_str)
 
         proc = Process(target=self._process_job, args=(job,))
@@ -199,7 +209,7 @@ class Worker(object):
 
         job.set_finished(failed)
 
-        return  failed
+        return failed
 
     def _process_job(self, job):
         '''
@@ -219,10 +229,12 @@ class Worker(object):
                 self._post(job)
 
     def _pre(self, job):
-        if self._pre_call: self._pre_call(job)
+        if self._pre_call:
+            self._pre_call(job)
 
     def _post(self, job):
-        if self._post_call: self._post_call(job)
+        if self._post_call:
+            self._post_call(job)
 
     def set_pre(self, func):
         self._pre_call = func
@@ -239,6 +251,7 @@ class Worker(object):
         return self.factory._items_cursor(queues=self.queues,
                                           tags=self.tags,
                                           ).count()
+
 
 class WorkerProxy(object):
     'This is a representation of an actual worker process'
@@ -291,8 +304,5 @@ class WorkerProxy(object):
     def finished(self):
         'test if this worker is finished'
         coll = self.factory.worker_collection
-        cursor = coll.find({'_id':self.id, 'working':False})
+        cursor = coll.find({'_id': self.id, 'working': False})
         return bool(cursor.count())
-
-
-

--- a/mtq/worker.py
+++ b/mtq/worker.py
@@ -216,7 +216,7 @@ class Worker(object):
         '''
         handle_signals()
 
-        with setup_logging(self.factory.logging_collection, job.id, lognames=self.extra_lognames):
+        with setup_logging(self.factory.logging_collection, job.id):
             try:
                 self._pre(job)
                 job.apply()

--- a/mtq/worker.py
+++ b/mtq/worker.py
@@ -10,7 +10,7 @@ import sys
 import time
 
 from mtq.log import MongoStream, MongoHandler
-from mtq.utils import handle_signals, now, setup_logging2, nulltime
+from mtq.utils import handle_signals, now, setup_logging, nulltime
 
 
 class Worker(object):
@@ -49,7 +49,7 @@ class Worker(object):
         '''
         Internal
         Contextmanager, register the birth and death of this worker
-        
+
         eg::
             with worker.register():
                 # Work
@@ -98,9 +98,9 @@ class Worker(object):
     def work(self, one=False, batch=False, failed=False, fail_fast=False):
         '''
         Main work function
-        
+
         :param one: wait for the first job execute and then exit
-        :param batch: work until the queue is empty, then exit 
+        :param batch: work until the queue is empty, then exit
         '''
         with self.register():
             try:
@@ -206,7 +206,7 @@ class Worker(object):
         '''
         handle_signals()
 
-        with setup_logging2(self.worker_id, job.id, lognames=self.extra_lognames):
+        with setup_logging(self.factory.logging_collection, self.worker_id, job.id, lognames=self.extra_lognames):
             try:
                 self._pre(job)
                 job.apply()


### PR DESCRIPTION
Messages logged within the worker processes were being captured, but only output in the case of failure. Now the captured logs are also saved into the mq.log collection in the database. 