### PR TITLE
Add logging to database collection

### DIFF
--- a/mtq/defaults.py
+++ b/mtq/defaults.py
@@ -3,6 +3,6 @@ Default values for the queue
 '''
 _collection_base = 'mq'
 _qsize = 50
-_logsize = 100
+_logsize = 1000
 _workersize = 5
 _task_map = {}

--- a/mtq/tests/fixture.py
+++ b/mtq/tests/fixture.py
@@ -1,12 +1,17 @@
 import unittest
 import pymongo
 import mtq
+import logging
 
+log = logging.getLogger('mtq.test')
+log.setLevel(logging.INFO)
 
 def test_func(*args, **kwargs):
+    log.info('Running test_func')
     return args, kwargs
 
 def test_func_fail(*args, **kwargs):
+    log.warning('Raising a test exception in test_func_fail')
     raise Exception()
 
 
@@ -20,6 +25,11 @@ class MTQTestCase(unittest.TestCase):
         self.factory = mtq.create_connection(db=self.db)
 
     def tearDown(self):
+        # uncomment to dump database state after each test
+        # from pprint import pprint
+        # for coll in self.db.collection_names():
+        #     print('\n%s:' % coll)
+        #     pprint(list(self.db[coll].find()))
         self.connection.drop_database('mtq_testing')
 
 

--- a/mtq/worker.py
+++ b/mtq/worker.py
@@ -10,7 +10,7 @@ import sys
 import time
 
 from mtq.log import MongoStream, MongoHandler
-from mtq.utils import handle_signals, now, setup_logging2, nulltime
+from mtq.utils import handle_signals, now, setup_logging, nulltime
 
 
 class Worker(object):
@@ -206,7 +206,7 @@ class Worker(object):
         '''
         handle_signals()
 
-        with setup_logging2(self.worker_id, job.id, lognames=self.extra_lognames):
+        with setup_logging(self.factory.logging_collection, job.id):
             try:
                 self._pre(job)
                 job.apply()


### PR DESCRIPTION
Messages logged within the worker processes were being captured, but only output in the case of failure. Now the captured logs are also saved into the mq.log collection in the database.

This is the same as #3 without whitespace and linting changes.